### PR TITLE
Add a basic Puma configuration file

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Hi.

Since Heroku [recommends](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server) generating a configuration file rather than setting values inline in the `Procfile`, I've added the basic `config/puma.rb` setup from their Deploying Rails Applications with the Puma Web Server article.

All the best,
O-I