### PR TITLE
Bump json to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)


### PR DESCRIPTION
Per flori/json#229, json 1.8.1 is incompatible with Ruby 2.2.0 (and possibly greater).  

This bumps the json gem to a 2.2.0-compatible version.

I wasn't able to find any contributing guidelines, so please let me know if I'm missing anything.