### PR TITLE
use statsd-ruby instead of statsd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,6 @@ gem 'puma'
 # gem 'debugger', group: [:development, :test]
 
 gem 'trashed'
-gem 'statsd'
+gem 'statsd-ruby'
 
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.4)
-    bson (4.2.2)
     builder (3.2.3)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -47,7 +46,6 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     erubis (2.7.0)
-    eventmachine (1.2.3)
     execjs (2.7.0)
     faker (1.7.3)
       i18n (~> 0.5)
@@ -71,8 +69,6 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    mongo (2.4.2)
-      bson (>= 4.2.1, < 5.0.0)
     multi_json (1.12.1)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
@@ -131,10 +127,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    statsd (0.5.4)
-      erubis (>= 2.6.6)
-      eventmachine (>= 0.12.10)
-      mongo (>= 1.2.4)
     statsd-ruby (1.4.0)
     thor (0.19.4)
     thread_safe (0.3.6)
@@ -164,7 +156,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   sdoc (~> 0.4.0)
   spring
-  statsd
+  statsd-ruby
   trashed
   turbolinks
   uglifier (>= 1.3.0)
@@ -173,4 +165,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 require 'trashed/railtie'
-require 'statsd'
+require 'statsd-ruby'
 
 
 module RubyGettingStarted


### PR DESCRIPTION
Fixes #24 

Looks like we were pulling in this older gem by mistake https://github.com/quasor/statsd