### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby '>= 2.3.5', '< 2.6'
 gem 'rails'
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 0.18'
-gem 'rails_12factor', group: :production
 # Use SCSS for stylesheets
 gem 'sass-rails'
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,11 +99,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -162,7 +157,6 @@ DEPENDENCIES
   pg (~> 0.18)
   puma
   rails
-  rails_12factor
   sass-rails
   sdoc
   spring
@@ -173,4 +167,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.16.5


### PR DESCRIPTION
See: https://github.com/heroku/rails_12factor#rails-5

> If you are starting a new application with Rails 5, you do not need this gem.