### PR TITLE
Allow a range of Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.5'
+ruby '>= 2.3.5', '< 2.6'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 2.3.5p376
+   ruby 2.4.4p296
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
I was helping a group of students go through this flow and when they get to this section https://devcenter.heroku.com/articles/getting-started-with-ruby#declare-app-dependencies it fails because they have a different Ruby version locally. 

This PR allows the app to boot in a variety of Ruby versions.