### PR TITLE
Update local bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,4 +225,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.2.28
+   2.3.24


### PR DESCRIPTION
There's a deprecation in Ruby 3.1 with this bundler version:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

Upgrading the version locally fixes the warning.