### PR TITLE
Faster nokogiri installs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     pg (1.3.5)
     psych (4.0.4)
       stringio
@@ -205,6 +207,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
With https://nokogiri.org/tutorials/installing_nokogiri.html#how-can-i-avoid-using-a-precompiled-native-gem nokogiri now ships pre-compiled. By locking to the x86 platform we are telling Bundler it's okay to install a platform specific gem. This is used to download and install nokogiri without having to wait for it to compile. This will save on build time.