### PR TITLE
Add name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,3 @@
-{}
+{
+  "name": "Ruby getting started guide"
+}


### PR DESCRIPTION
The Node CNB requires this field in package.json (even though technically by spec it's not required). This is a blocker for merging https://github.com/heroku/builder/pull/311.