### PR TITLE
Remove unneeded config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,11 +7,5 @@ preload_app!
 port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
-on_worker_boot do
-  # Worker specific setup for Rails 4.1+
-  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-  ActiveRecord::Base.establish_connection
-end
-
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
This connection logic hasn't been required since Rails ~4.1. We can remove it from this Rails 7 app.