### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      ruby-dependencies:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
To keep the deps in this project up to date. Grouping has been enabled to reduce the number of PRs/noise.

Docs:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file