### PR TITLE
Upgrade Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '>= 3.1', '< 3.3'
+ruby '>= 3.1', '< 3.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 7.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 3.1.3p185
+   ruby 3.2.4p170
 
 BUNDLED WITH
-   2.4.7
+   2.5.9


### PR DESCRIPTION
3.0 is now EOL. 3.3 is the latest. We typically target the middle release (3.2 in this case) as a stable middle ground.

I want to update the tutorials (including https://github.com/heroku/buildpacks/pull/18) to use a Ruby with the latest security updates https://devcenter.heroku.com/changelog-items/2867