### PR TITLE
Add viewport meta tag to HTML head

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Ruby Getting Started on Heroku</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= stylesheet_link_tag  '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css' %>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>


### PR DESCRIPTION
Much better page dimensions and scaling on mobile devices; this tag is standard practice for HTML these days.

Also see https://github.com/heroku/php-getting-started/pull/74

GUS-W-16610879