### PR TITLE
Add IPv6 support

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,8 @@ threads threads_count, threads_count
 
 preload_app!
 
-port        ENV.fetch("PORT") { 3000 }
+# Support IPv6 by binding to host `::` instead of `0.0.0.0`
+port(ENV.fetch("PORT") { 3000 }, "::")
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.


### PR DESCRIPTION
Short: The industry is moving from IPv4 and IPv6 is the future. Here's some more context https://github.com/heroku/roadmap/issues/40.

Internal Heroku link for more context: https://salesforce-internal.slack.com/archives/C06NM9FFY57/p1732035124610499?thread_ts=1731970807.940289&cid=C06NM9FFY57


```
⛄️ 3.3.1 🚀 /Users/rschneeman/Documents/projects/ruby-getting-started (schneems/ipv6)
$ git push heroku schneems/ipv6:main
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Updated 105 paths from 7f93463

remote: Compressing source files... done.
remote: Building source:

heroku open
remote:
remote: -----> Building on the Heroku-24 stack
remote: -----> Determining which buildpack to use for this app
remote:  !     Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
remote: 			Detected buildpacks: Ruby,Node.js
remote: 			See https://devcenter.heroku.com/articles/buildpacks#buildpack-detect-order
remote: -----> Ruby app detected
remote: -----> Installing bundler 2.5.6
remote: -----> Removing BUNDLED WITH version in the Gemfile.lock
remote: -----> Compiling Ruby/Rails
remote: -----> Using Ruby version: ruby-3.2.4
remote: -----> Installing dependencies using bundler 2.5.6
remote:        Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
remote:        Fetching gem metadata from https://rubygems.org/.........
remote:        Fetching rake 13.2.1
remote:        Installing rake 13.2.1
remote:        Fetching base64 0.2.0
remote:        Fetching connection_pool 2.4.1
remote:        Fetching bigdecimal 3.1.8
remote:        Fetching concurrent-ruby 1.2.3
remote:        Installing base64 0.2.0
remote:        Installing connection_pool 2.4.1
remote:        Fetching drb 2.2.1
remote:        Fetching minitest 5.23.0
remote:        Installing drb 2.2.1
remote:        Installing bigdecimal 3.1.8 with native extensions
remote:        Installing minitest 5.23.0
remote:        Fetching mutex_m 0.2.0
remote:        Installing concurrent-ruby 1.2.3
remote:        Installing mutex_m 0.2.0
remote:        Fetching builder 3.2.4
remote:        Installing builder 3.2.4
remote:        Fetching erubi 1.12.0
remote:        Installing erubi 1.12.0
remote:        Fetching racc 1.7.3
remote:        Fetching crass 1.0.6
remote:        Installing racc 1.7.3 with native extensions
remote:        Installing crass 1.0.6
remote:        Fetching rack 3.0.11
remote:        Installing rack 3.0.11
remote:        Fetching nio4r 2.7.3
remote:        Fetching websocket-extensions 0.1.5
remote:        Installing websocket-extensions 0.1.5
remote:        Fetching zeitwerk 2.6.14
remote:        Installing nio4r 2.7.3 with native extensions
remote:        Installing zeitwerk 2.6.14
remote:        Fetching timeout 0.4.1
remote:        Installing timeout 0.4.1
remote:        Fetching marcel 1.0.4
remote:        Installing marcel 1.0.4
remote:        Fetching mini_mime 1.1.5
remote:        Installing mini_mime 1.1.5
remote:        Fetching date 3.3.4
remote:        Installing date 3.3.4 with native extensions
remote:        Fetching msgpack 1.7.2
remote:        Installing msgpack 1.7.2 with native extensions
remote:        Fetching coffee-script-source 1.12.2
remote:        Installing coffee-script-source 1.12.2
remote:        Fetching execjs 2.8.1
remote:        Installing execjs 2.8.1
remote:        Fetching stringio 3.1.0
remote:        Installing stringio 3.1.0 with native extensions
remote:        Fetching io-console 0.7.2
remote:        Installing io-console 0.7.2 with native extensions
remote:        Fetching webrick 1.8.1
remote:        Installing webrick 1.8.1
remote:        Fetching thor 1.3.1
remote:        Installing thor 1.3.1
remote:        Fetching ffi 1.16.3
remote:        Installing ffi 1.16.3 with native extensions
remote:        Fetching rb-fsevent 0.11.2
remote:        Installing rb-fsevent 0.11.2
remote:        Fetching pg 1.5.6
remote:        Installing pg 1.5.6 with native extensions
remote:        Fetching tilt 2.1.0
remote:        Installing tilt 2.1.0
remote:        Fetching turbolinks-source 5.2.0
remote:        Installing turbolinks-source 5.2.0
remote:        Fetching i18n 1.14.5
remote:        Installing i18n 1.14.5
remote:        Fetching tzinfo 2.0.6
remote:        Installing tzinfo 2.0.6
remote:        Fetching rack-session 2.0.0
remote:        Installing rack-session 2.0.0
remote:        Fetching rack-test 2.1.0
remote:        Installing rack-test 2.1.0
remote:        Fetching sprockets 4.2.0
remote:        Installing sprockets 4.2.0
remote:        Fetching websocket-driver 0.7.6
remote:        Installing websocket-driver 0.7.6 with native extensions
remote:        Fetching net-protocol 0.2.2
remote:        Installing net-protocol 0.2.2
remote:        Fetching nokogiri 1.16.5 (x86_64-linux)
remote:        Installing nokogiri 1.16.5 (x86_64-linux)
remote:        Fetching puma 6.4.2
remote:        Installing puma 6.4.2 with native extensions
remote:        Fetching coffee-script 2.4.1
remote:        Installing coffee-script 2.4.1
remote:        Fetching uglifier 4.2.0
remote:        Installing uglifier 4.2.0
remote:        Fetching psych 5.1.2
remote:        Installing psych 5.1.2 with native extensions
remote:        Fetching bootsnap 1.18.3
remote:        Installing bootsnap 1.18.3 with native extensions
remote:        Fetching rackup 2.1.0
remote:        Installing rackup 2.1.0
remote:        Fetching reline 0.5.7
remote:        Installing reline 0.5.7
remote:        Fetching turbolinks 5.2.1
remote:        Installing turbolinks 5.2.1
remote:        Fetching net-imap 0.4.11
remote:        Installing net-imap 0.4.11
remote:        Fetching net-pop 0.1.2
remote:        Installing net-pop 0.1.2
remote:        Fetching net-smtp 0.5.0
remote:        Installing net-smtp 0.5.0
remote:        Fetching loofah 2.22.0
remote:        Installing loofah 2.22.0
remote:        Fetching activesupport 7.1.3.2
remote:        Installing activesupport 7.1.3.2
remote:        Fetching rdoc 6.6.3.1
remote:        Installing rdoc 6.6.3.1
remote:        Fetching rb-inotify 0.10.1
remote:        Installing rb-inotify 0.10.1
remote:        Fetching sassc 2.4.0
remote:        Installing sassc 2.4.0 with native extensions
remote:        Fetching mail 2.8.1
remote:        Installing mail 2.8.1
remote:        Fetching rails-html-sanitizer 1.6.0
remote:        Installing rails-html-sanitizer 1.6.0
remote:        Fetching rails-dom-testing 2.2.0
remote:        Installing rails-dom-testing 2.2.0
remote:        Fetching globalid 1.2.1
remote:        Installing globalid 1.2.1
remote:        Fetching activemodel 7.1.3.2
remote:        Installing activemodel 7.1.3.2
remote:        Fetching irb 1.13.1
remote:        Installing irb 1.13.1
remote:        Fetching sdoc 2.6.1
remote:        Installing sdoc 2.6.1
remote:        Fetching listen 3.9.0
remote:        Installing listen 3.9.0
remote:        Fetching actionview 7.1.3.2
remote:        Installing actionview 7.1.3.2
remote:        Fetching activejob 7.1.3.2
remote:        Installing activejob 7.1.3.2
remote:        Fetching activerecord 7.1.3.2
remote:        Fetching actionpack 7.1.3.2
remote:        Installing activerecord 7.1.3.2
remote:        Installing actionpack 7.1.3.2
remote:        Fetching jbuilder 2.12.0
remote:        Installing jbuilder 2.12.0
remote:        Fetching actioncable 7.1.3.2
remote:        Installing actioncable 7.1.3.2
remote:        Fetching actionmailer 7.1.3.2
remote:        Installing actionmailer 7.1.3.2
remote:        Fetching railties 7.1.3.2
remote:        Installing railties 7.1.3.2
remote:        Fetching sprockets-rails 3.4.2
remote:        Installing sprockets-rails 3.4.2
remote:        Fetching activestorage 7.1.3.2
remote:        Installing activestorage 7.1.3.2
remote:        Fetching actionmailbox 7.1.3.2
remote:        Installing actionmailbox 7.1.3.2
remote:        Fetching actiontext 7.1.3.2
remote:        Installing actiontext 7.1.3.2
remote:        Fetching coffee-rails 5.0.0
remote:        Fetching jquery-rails 4.6.0
remote:        Installing coffee-rails 5.0.0
remote:        Fetching rails 7.1.3.2
remote:        Installing rails 7.1.3.2
remote:        Installing jquery-rails 4.6.0
remote:        Fetching sassc-rails 2.1.2
remote:        Installing sassc-rails 2.1.2
remote:        Fetching sass-rails 6.0.0
remote:        Installing sass-rails 6.0.0
remote:        Bundle complete! 13 Gemfile dependencies, 82 gems now installed.
remote:        Gems in the groups 'development' and 'test' were not installed.
remote:        Bundled gems are installed into `./vendor/bundle`
remote:        Bundle completed (72.17s)
remote:        Cleaning up the bundler cache.
remote:        Removing bundler (2.5.6)
remote:
remote: ###### WARNING:
remote:
remote:        Installing a default version (22.11.0) of Node.js.
remote:        This version is not pinned and can change over time, causing unexpected failures.
remote:
remote:        Heroku recommends placing the `heroku/nodejs` buildpack in front of
remote:        `heroku/ruby` to install a specific version of node:
remote:
remote:        https://devcenter.heroku.com/articles/ruby-support#node-js-support
remote:
remote: -----> Installing node-v22.11.0-linux-x64
remote: -----> Detecting rake tasks
remote: -----> Preparing app for Rails asset pipeline
remote:        Running: rake assets:precompile
remote:        I, [2024-11-22T22:21:14.823763 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/manifest-dad05bf766af0fe3d79dd746db3c1361c0583026cdf35d6a2921bccaea835331.js
remote:        I, [2024-11-22T22:21:14.824114 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/manifest-dad05bf766af0fe3d79dd746db3c1361c0583026cdf35d6a2921bccaea835331.js.gz
remote:        I, [2024-11-22T22:21:14.824261 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/lang-logo-b6c7c4b6a37e9c2425ca4d54561010c0719870ae325c849de398499f1ab098a9.png
remote:        I, [2024-11-22T22:21:14.824609 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/application-9ced36c9568ebfd1053e04ba411af767274dfcccd9807c0989f8bd17ca5e8f5b.js
remote:        I, [2024-11-22T22:21:14.824773 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/application-9ced36c9568ebfd1053e04ba411af767274dfcccd9807c0989f8bd17ca5e8f5b.js.gz
remote:        I, [2024-11-22T22:21:14.825152 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/welcome-27cfb9694c5e92d25d972c2b4a2d2e222ad088aef866823f772241c1db423402.js
remote:        I, [2024-11-22T22:21:14.825496 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/welcome-27cfb9694c5e92d25d972c2b4a2d2e222ad088aef866823f772241c1db423402.js.gz
remote:        I, [2024-11-22T22:21:14.825681 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/widgets-27cfb9694c5e92d25d972c2b4a2d2e222ad088aef866823f772241c1db423402.js
remote:        I, [2024-11-22T22:21:14.825837 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/widgets-27cfb9694c5e92d25d972c2b4a2d2e222ad088aef866823f772241c1db423402.js.gz
remote:        I, [2024-11-22T22:21:14.825928 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/application-776d900b9840362472b5b6b4afb9b798c78d53098a77b289b8bfc22c6d241913.css
remote:        I, [2024-11-22T22:21:14.825994 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/application-776d900b9840362472b5b6b4afb9b798c78d53098a77b289b8bfc22c6d241913.css.gz
remote:        I, [2024-11-22T22:21:14.826066 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/scaffolds-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.css
remote:        I, [2024-11-22T22:21:14.826133 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/scaffolds-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.css.gz
remote:        I, [2024-11-22T22:21:14.826482 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/theme-776d900b9840362472b5b6b4afb9b798c78d53098a77b289b8bfc22c6d241913.css
remote:        I, [2024-11-22T22:21:14.826927 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/theme-776d900b9840362472b5b6b4afb9b798c78d53098a77b289b8bfc22c6d241913.css.gz
remote:        I, [2024-11-22T22:21:14.827042 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/welcome-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.css
remote:        I, [2024-11-22T22:21:14.827166 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/welcome-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.css.gz
remote:        I, [2024-11-22T22:21:14.827725 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/widgets-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.css
remote:        I, [2024-11-22T22:21:14.827806 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/widgets-04024382391bb910584145d8113cf35ef376b55d125bb4516cebeb14ce788597.css.gz
remote:        I, [2024-11-22T22:21:14.827895 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actiontext-78de0ebeae470799f9ec25fd0e20ae2d931df88c2ff9315918d1054a2fca2596.js
remote:        I, [2024-11-22T22:21:14.828286 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actiontext-78de0ebeae470799f9ec25fd0e20ae2d931df88c2ff9315918d1054a2fca2596.js.gz
remote:        I, [2024-11-22T22:21:14.828570 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actiontext.esm-328ef022563f73c1b9b45ace742bd21330da0f6bd6c1c96d352d52fc8b8857e5.js
remote:        I, [2024-11-22T22:21:14.829053 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actiontext.esm-328ef022563f73c1b9b45ace742bd21330da0f6bd6c1c96d352d52fc8b8857e5.js.gz
remote:        I, [2024-11-22T22:21:14.829137 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/trix-e17a480fcb4e30c8571f0fed42dc81de5faeef93755ca30fe9623eb3f5c709e5.js
remote:        I, [2024-11-22T22:21:14.829203 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/trix-e17a480fcb4e30c8571f0fed42dc81de5faeef93755ca30fe9623eb3f5c709e5.js.gz
remote:        I, [2024-11-22T22:21:14.829292 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/trix-5552afe828fe79c41e53b9cc3616e9d7b8c2de1979ea62cbd663b88426ec41de.css
remote:        I, [2024-11-22T22:21:14.829760 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/trix-5552afe828fe79c41e53b9cc3616e9d7b8c2de1979ea62cbd663b88426ec41de.css.gz
remote:        I, [2024-11-22T22:21:14.830045 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/activestorage-503a4fe23aabfbcb752dad255f01835904e6961d5f20d1de13987a691c27d9cd.js
remote:        I, [2024-11-22T22:21:14.830098 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/activestorage-503a4fe23aabfbcb752dad255f01835904e6961d5f20d1de13987a691c27d9cd.js.gz
remote:        I, [2024-11-22T22:21:14.830191 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/activestorage.esm-b3f7f0a5ef90530b509c5e681c4b3ef5d5046851e5b70d57fdb45e32b039c883.js
remote:        I, [2024-11-22T22:21:14.830262 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/activestorage.esm-b3f7f0a5ef90530b509c5e681c4b3ef5d5046851e5b70d57fdb45e32b039c883.js.gz
remote:        I, [2024-11-22T22:21:14.830350 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actioncable-1c7f008c6deb7b55c6878be38700ff6bf56b75444a086fa1f46e3b781365a3ea.js
remote:        I, [2024-11-22T22:21:14.830418 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actioncable-1c7f008c6deb7b55c6878be38700ff6bf56b75444a086fa1f46e3b781365a3ea.js.gz
remote:        I, [2024-11-22T22:21:14.830729 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actioncable.esm-06609b0ecaffe2ab952021b9c8df8b6c68f65fc23bee728fc678a2605e1ce132.js
remote:        I, [2024-11-22T22:21:14.830810 #1812]  INFO -- : Writing /tmp/build_fd7a70ba/public/assets/actioncable.esm-06609b0ecaffe2ab952021b9c8df8b6c68f65fc23bee728fc678a2605e1ce132.js.gz
remote:        Asset precompilation completed (1.09s)
remote:        Cleaning assets
remote:        Running: rake assets:clean
remote: -----> Detecting rails configuration
remote:
remote: ###### WARNING:
remote:
remote:        Installing a default version (22.11.0) of Node.js.
remote:        This version is not pinned and can change over time, causing unexpected failures.
remote:
remote:        Heroku recommends placing the `heroku/nodejs` buildpack in front of
remote:        `heroku/ruby` to install a specific version of node:
remote:
remote:        https://devcenter.heroku.com/articles/ruby-support#node-js-support
remote:
remote: ###### WARNING:
remote:
remote:        There is a more recent Ruby version available for you to use:
remote:
remote:        3.2.6
remote:
remote:        The latest version will include security and bug fixes. We always recommend
remote:        running the latest version of your minor release.
remote:
remote:        Please upgrade your Ruby version.
remote:
remote:        For all available Ruby versions see:
remote:          https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
remote:
remote:
remote: -----> Discovering process types
remote:        Procfile declares types     -> web
remote:        Default types for buildpack -> console, rake
remote:
remote: -----> Compressing...
remote:        Done: 87.7M
remote: -----> Launching...
remote:        Released v4
remote:        https://agile-lake-21342-4d576423cca4.herokuapp.com/ deployed to Heroku
remote:
remote: Verifying deploy... done.
To https://git.heroku.com/agile-lake-21342.git
 * [new branch]      schneems/ipv6 -> main
⛄️ 3.3.1 🚀 /Users/rschneeman/Documents/projects/ruby-getting-started (schneems/ipv6)
$
⛄️ 3.3.1 🚀 /Users/rschneeman/Documents/projects/ruby-getting-started (schneems/ipv6)
$
⛄️ 3.3.1 🚀 /Users/rschneeman/Documents/projects/ruby-getting-started (schneems/ipv6)
$ heroku open
⛄️ 3.3.1 🚀 /Users/rschneeman/Documents/projects/ruby-getting-started (schneems/ipv6)
$ heroku logs
2024-11-22T22:19:34.942060+00:00 app[api]: Initial release by user richard@heroku.com
2024-11-22T22:19:34.942060+00:00 app[api]: Release v1 created by user richard@heroku.com
2024-11-22T22:19:35.240176+00:00 app[api]: Enable Logplex by user richard@heroku.com
2024-11-22T22:19:35.240176+00:00 app[api]: Release v2 created by user richard@heroku.com
2024-11-22T22:19:51.000000+00:00 app[api]: Build started by user richard@heroku.com
2024-11-22T22:21:22.128367+00:00 app[api]: Release v3 created by user richard@heroku.com
2024-11-22T22:21:22.128367+00:00 app[api]: Set LANG, RACK_ENV, RAILS_ENV, RAILS_LOG_TO_STDOUT, RAILS_SERVE_STATIC_FILES, SECRET_KEY_BASE config vars by user richard@heroku.com
2024-11-22T22:21:22.777592+00:00 app[api]: Release v4 created by user richard@heroku.com
2024-11-22T22:21:22.777592+00:00 app[api]: Deploy 495526a4 by user richard@heroku.com
2024-11-22T22:21:22.794901+00:00 app[api]: Scaled to console@0:Basic rake@0:Basic web@1:Basic by user richard@heroku.com
2024-11-22T22:21:26.137651+00:00 heroku[web.1]: Starting process with command `bundle exec puma -C config/puma.rb`
2024-11-22T22:21:26.859221+00:00 app[web.1]: [2] Puma starting in cluster mode...
2024-11-22T22:21:26.859243+00:00 app[web.1]: [2] * Puma version: 6.4.2 (ruby 3.2.4-p170) ("The Eagle of Durango")
2024-11-22T22:21:26.859243+00:00 app[web.1]: [2] *  Min threads: 5
2024-11-22T22:21:26.859243+00:00 app[web.1]: [2] *  Max threads: 5
2024-11-22T22:21:26.859244+00:00 app[web.1]: [2] *  Environment: production
2024-11-22T22:21:26.859244+00:00 app[web.1]: [2] *   Master PID: 2
2024-11-22T22:21:26.859244+00:00 app[web.1]: [2] *      Workers: 2
2024-11-22T22:21:26.859259+00:00 app[web.1]: [2] *     Restarts: (✔) hot (✖) phased
2024-11-22T22:21:26.859259+00:00 app[web.1]: [2] * Preloading application
2024-11-22T22:21:28.000000+00:00 app[api]: Build succeeded
2024-11-22T22:21:28.618121+00:00 app[web.1]: [2] * Listening on http://[::]:16066
2024-11-22T22:21:28.618176+00:00 app[web.1]: [2] Use Ctrl-C to stop
2024-11-22T22:21:28.627102+00:00 app[web.1]: [2] - Worker 0 (PID: 6) booted in 0.0s, phase: 0
2024-11-22T22:21:28.627447+00:00 app[web.1]: [2] - Worker 1 (PID: 11) booted in 0.0s, phase: 0
2024-11-22T22:21:28.801991+00:00 heroku[web.1]: State changed from starting to up
2024-11-22T22:21:32.339073+00:00 app[web.1]: I, [2024-11-22T22:21:32.338931 #11]  INFO -- : [f757abd
```