### PR TITLE
Update keepalive timeout with Router 2.0 settings

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -2,10 +2,14 @@ workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads threads_count, threads_count
 
+preload_app!
+
 # Router keepalive idle timeout + 5 seconds
 persistent_timeout(95)
 
-preload_app!
+# Turn off keepalive support for better long tails response time with Router 2.0
+# Remove this line when https://github.com/puma/puma/issues/3487 is closed, and the fix is released
+enable_keep_alives(false) if respond_to?(:enable_keep_alives)
 
 # Support IPv6 by binding to host `::` instead of `0.0.0.0`
 port(ENV.fetch("PORT") { 3000 }, "::")


### PR DESCRIPTION
Router 2.0 introduced keepalive support. It will close connections idle after 90 seconds https://devcenter.heroku.com/articles/http-routing#keepalives. We want to avoid a situation where they send a request right before puma closes the connection. We can do that by setting it to the same timeout the router uses + some value (such as 5 seconds). 

This timeout is used in the reactor when buffering unfinished request bodies and waiting for new requests on a still open client connection. If a connection is closed incorrectly and doesn't send a TCP `FIN` this timeout will prevent puma holding onto that connection forever.

There is currently a problem in puma 6x and prior with keepalives that causes high request variance https://github.com/puma/puma/issues/3487. So it's recommended that puma users disable keepalive connections by until that problem is fixed upstream:

```
$ heroku labs:enable http-disable-keepalive-to-dyno
```

GUS-W-19166166