### PR TITLE
Add arm platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,9 +140,12 @@ GEM
     nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.9-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     pg (1.6.0)
+    pg (1.6.0-aarch64-linux)
     pg (1.6.0-x86_64-linux)
     pp (0.6.2)
       prettyprint
@@ -239,6 +242,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux
   ruby
   x86_64-linux
 


### PR DESCRIPTION
The CNB buildpacks support ARM which is the architecture used on Fir. Adding to that platform list allows bundler to use precompiled binaries when deploying to arm (if they exist).

```
$ bundle lock --add-platform  aarch64-linux
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Writing lockfile to /Users/rschneeman/Documents/projects/work/getting-started-guides/ruby-getting-started/Gemfile.lock
```