### PR TITLE
Fix tutorial build/runtime warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ DEPENDENCIES
   spring
 
 RUBY VERSION
-  ruby 3.4.8p72
+  ruby 3.4.9
 
 BUNDLED WITH
   4.0.5

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,1 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  config.active_storage.variant_processor = :disabled
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  config.active_storage.variant_processor = :disabled
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
+  config.active_storage.variant_processor = :disabled
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the


### PR DESCRIPTION
The Heroku Getting Started with Ruby tutorial builds produce several warnings that are visible to readers and make the tutorial look broken or outdated:

- Asset precompilation and `rake db:migrate` both print "Generating image variants require the image_processing gem..." — readers may think they need to fix something.
- `heroku logs --tail` shows "Importmap skipped missing path: application.js" three times — noisy and confusing in what should be clean log output.
- `git push heroku main` build output includes a multi-line WARNING block suggesting Ruby 3.4.9 when the app uses 3.4.8 — implies the tutorial is out of date.

These appear in both the Fir and Classic tutorial output.